### PR TITLE
Quick clearup on config_rrf.ini

### DIFF
--- a/Copy to SD Card root directory to update/config_rrf.ini
+++ b/Copy to SD Card root directory to update/config_rrf.ini
@@ -1,6 +1,6 @@
 #--------------------------------------------------------------------
 #
-# DEFAULT CONFIG FILE FOR BigTreeTech TFT CONTROLLERS
+# DEFAULT CONFIG FILE FOR BigTreeTech TFT CONTROLLERS FOR RRF
 #
 #--------------------------------------------------------------------
 
@@ -32,29 +32,7 @@
 # Config.g Changes
 #   Add the following line to your config.g to enable the screen.
 #
-#   M575 P1 S2 B57600
-#
-# Start.g Changes
-#   Add the following line in your start.g file to allow the screen to know when a job has started.
-#
-#   M409 K"job.file.fileName"
-#
-# Stop.g Changes
-#   Add the following line in your stop.g file to allow the screen to know when a job has stopped.
-#
-#   M118 P2 S"//action:cancel"
-#
-#   M0 also need to be added to your stop gcode in your slicer to allow stop.g to be ran.
-#
-# Pause.g Changes
-#   Add the following line in your pause.g file to allow the screen to know when a job has been aused.
-#
-#   M118 P2 S"//action::paused"
-#
-# Cancel.g Changes
-#   Add the following line in your cancel.g file to allow the screen to know when a job has been cancelled.
-#
-#   M118 P2 S"//action::prompt_begin Resuming"
+#   M575 P1 S1 B57600
 #
 # In case you need help, please visit: https://discord.com/invite/uS97Qs7 or https://teamgloomy.github.io/
 
@@ -95,7 +73,7 @@ serial_port:P1:5 P2:0 P3:0 P4:0
 # NOTE: Enable it in case Marlin firmware does not properly support M600 on the mainboard.
 #
 #   Options: [disable: 0, enable: 1]
-emulated_m600:1
+emulated_m600:0
 
 #### Emulated M109 And M190
 # The TFT intercepts the blocking M109 and M190 G-codes (set target hotend and bed temperatures)
@@ -106,7 +84,7 @@ emulated_m600:1
 #       frozen until desired/set temperatures are obtained.
 #
 #   Options: [disable: 0, enable: 1]
-emulated_m109_m190:1
+emulated_m109_m190:0
 
 
 #--------------------------------------------------------------------
@@ -321,7 +299,7 @@ marlin_fullscreen:0
 #### Show Marlin Mode Title
 # Show banner text at the top of the TFT in Marlin Mode.
 #   Options: [disable: 0, enable: 1]
-marlin_show_title:1
+marlin_show_title:0
 
 #### Marlin Mode Title
 # Banner text displayed at the top of the TFT in Marlin Mode.
@@ -596,98 +574,6 @@ preheat_temp_6:T250 B90
 
 
 #--------------------------------------------------------------------
-# Power Supply Settings (only if connected to TFT controller)
-#--------------------------------------------------------------------
-
-#### Active HIGH Power Supply Logic
-# Used in case it is supported by the TFT.
-# The power supply uses this HIGH signal logic to stay ON.
-# The power supply uses the opposite of this logic to stay OFF.
-#   Options: [disable: 0, enable: 1]
-ps_active_high:1
-
-#### Power Supply Auto Shutdown Mode
-# Used in case it is supported by the TFT.
-# Enable power supply auto shutdown after a print is finished when hotend temperature drops below target value.
-#   Options: [disable: 0, enable: 1, auto-detect: 2]
-ps_auto_shutdown:0
-
-#### Power Supply Auto Shutdown Temperature
-# Maximum hotend temperature for automatic shutdown after printing, if automatic shutdown is enabled.
-# The printer will shutdown automatically if the hotend temperature is below this value.
-# If the hotend temperature is higher than this value the fans will be turned on to cooldown and it
-# will wait for the hotend temperature to drop below this value before shutting down automatically.
-#   Unit: [temperature in °C]
-#   Value range: [min: 20, max: 1000]
-ps_auto_shutdown_temp:50
-
-
-#--------------------------------------------------------------------
-# Filament Runout Settings (only if connected to TFT controller)
-#--------------------------------------------------------------------
-
-# NOTES for users having a filament sensor connected to the mainboard:
-#   1) Define "fil_runout:0" below to disable the sensor handling on the TFT.
-#   2) Configure the sensor in the firmware of your mainboard.
-#   3) Add M75 to "start_gcode" and M77 to "end_gcode" of the TFT (or your slicer).
-
-#### Filament Runout Sensor
-# Select the type of filament runout sensor and its default enabled/disabled state.
-#   Options: [Normal Disabled: 0, Normal Enabled: 1, Smart Disabled: 2, Smart Enabled: 3]
-fil_runout:0
-
-#### Inverted Filament Runout Sensor Logic
-# The sensor uses an inverted logic.
-#   Options: [disable: 0, enable: 1]
-fil_runout_inverted:1
-
-#### NC (Normal Close) Filament Runout Sensor
-# The sensor is of type NC.
-#   Options: [Normal Open: 0, Normal Close: 1]
-fil_runout_nc:1
-
-#### Filament Runout Noise Threshold
-# Pause print when filament runout is detected at least for this time period.
-#   Unit: [time in miliseconds]
-#   Value range: [min: 10, max: 1800]
-fil_runout_noise_threshold:100
-
-#### Smart Filament Runout Detection
-# Used in conjuction with an SFS (Smart Filamanent Sensor) based on an encoder disc that
-# toggles runout pin as filament moves.
-#   Unit: [distance in mm]
-#   Value range: [min: 1, max: 50]
-fil_runout_distance:7
-
-
-#--------------------------------------------------------------------
-# Power Loss Recovery & BTT UPS Settings
-#--------------------------------------------------------------------
-
-#### Power Loss Recovery Mode
-# Enable power loss recovery.
-# Disable to reduce the loss of SD card or U disk.
-#   Options: [disable: 0, enable: 1]
-pl_recovery:1
-
-#### Power Loss Recovery Homing
-# Home before power loss recovery.
-#   Options: [disable: 0, enable: 1]
-pl_recovery_home:0
-
-#### Power Loss Recovery Z Raise
-# Raise Z axis on resume (on power loss with UPS).
-#   Unit: [distance in mm]
-#   Value range: [min: 0, max: 2000]
-pl_recovery_z_raise:10
-
-#### BTT Mini UPS Support
-# Enable backup power/UPS to move Z axis on power loss.
-#   Options: [disable: 0, enable: 1]
-btt_mini_ups:0
-
-
-#--------------------------------------------------------------------
 # Other Device-Specific Settings
 #--------------------------------------------------------------------
 
@@ -753,88 +639,3 @@ knob_led_idle:1
 # Greater than 0 means the number of LEDs in the strip.
 #   Value range: [min: 0, max: 200]
 neopixel_pixels:0
-
-
-#--------------------------------------------------------------------
-# Custom G-code Commands
-#--------------------------------------------------------------------
-
-#### Custom G-code Commands
-# Up to 15 custom G-code commands that will be available in the Custom menu.
-#
-# Usage:
-#   - To enable a custom command, remove "#" at the begining of custom commands label & G-code.
-#   - To disable a custom command, add "#" at the begining of custom commands label & G-code.
-#
-# NOTE: If the values are left blank then default name and G-code will be used.
-#
-#   Value range: label: [min: 3, max: 75 characters]
-#                G-code: [min: 3, max: 75 characters]
-custom_label_1:Disable steppers
-custom_gcode_1:M84\n
-custom_label_2:Init sd card
-custom_gcode_2:M21\n
-custom_label_3:Release sd card
-custom_gcode_3:M22\n
-custom_label_4:Restore leveling
-custom_gcode_4:M420 S1\n
-custom_label_5:Save to EEPROM
-custom_gcode_5:M500\n
-custom_label_6:Restore from EEPROM
-custom_gcode_6:M501\n
-custom_label_7:EEPROM defaults
-custom_gcode_7:M502\n
-#custom_label_8:custom8
-#custom_gcode_8:M105\n
-#custom_label_9:custom9
-#custom_gcode_9:M105\n
-#custom_label_10:custom10
-#custom_gcode_10:M105\n
-#custom_label_11:custom11
-#custom_gcode_11:M105\n
-#custom_label_12:custom12
-#custom_gcode_12:M105\n
-#custom_label_13:custom13
-#custom_gcode_13:M105\n
-#custom_label_14:custom14
-#custom_gcode_14:M105\n
-#custom_label_15:custom15
-#custom_gcode_15:M105\n
-
-
-#--------------------------------------------------------------------
-# Start, End & Cancel G-code Commands
-#--------------------------------------------------------------------
-
-# NOTES for users having a filament sensor connected to the mainboard:
-#   1) Enable the start/end G-code below.
-#   2) Add the following commands to the start/end G-code:
-#      - start_gcode: M75\n
-#      - end_gcode: M77\n
-
-#### Start G-code Status
-#   Options: [disable: 0, enable: 1]
-start_gcode_enabled:0
-
-#### End G-code Status
-#   Options: [disable: 0, enable: 1]
-end_gcode_enabled:0
-
-#### Cancel G-code Status
-#   Options: [disable: 0, enable: 1]
-cancel_gcode_enabled:0
-
-#### Start G-code
-# This G-code will run before starting a print if "start_gcode_enabled" is enabled.
-#   Value range: [min: 3, max: 75 characters]
-start_gcode:G28 XY R20\n
-
-#### End G-code
-# This G-code will run after a print is completed if "end_gcode_enabled" is enabled.
-#   Value range: [min: 3, max: 75 characters]
-end_gcode:M104 S0\nM140 S0\nM107\nM18\n
-
-#### Cancel G-code
-# This G-code will run when a print is canceled if "cancel_gcode_enabled" is enabled.
-#   Value range: [min: 3, max: 75 characters]
-cancel_gcode:M104 S0\nM140 S0\nG28 XY R10\nM107\nM18\n


### PR DESCRIPTION
The settings which makes no sense for RRF users are removed for a clearer config.ini for us if we have one :)
@pfn If you have time please check if I removed anything that's needed. I tested this shortened config.ini, and the TFT ran fine with it.
@digant73 @bigtreetech If this approach is acceptable please merge it, and in the future, I try to maintain config.ini and tweak it to the RRF user's needs more.